### PR TITLE
Feedback

### DIFF
--- a/feedback/defensive-colmeans-sol.Rmd
+++ b/feedback/defensive-colmeans-sol.Rmd
@@ -1,0 +1,71 @@
+```{r, child = "defensive-colmeans-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+
+Minimalstlösung:
+```{r, col_means_def_1}
+# compute means of all numeric columns in df
+# input: a data.frame
+# output: a data.frame contianing the column means
+col_means <- function(df) {
+  stopifnot(is.data.frame(df), all(dim(df)) > 0)
+
+  numeric <- sapply(df, is.numeric)
+  df_numeric <- df[, numeric, drop = FALSE]
+
+  data.frame(vapply(df_numeric, mean, numeric(1)))
+}
+```
+```{r, col_means_test, error = TRUE}
+```
+
+Etwas ausgefeilter:
+```{r, col_means_def_2}
+# compute means of all columns in df for whose class "mean" is defined
+# df: anything that can be converted to a data.frame
+# na.rm: drop NAs?
+# output: a data.frame containing the column means of all numeric columns
+col_means <- function(df, na.rm = FALSE) {
+  checkmate::assert_flag(na.rm)
+  if (!is.data.frame(df)) {
+    df <- try(as.data.frame(df))
+    if (inherits(df, "try-error")) {
+      stop("<df> not convertable to a data.frame")
+    } else {
+      message("<df> converted to data.frame.")
+    }
+  }
+  
+  
+  # see methods("mean") for data types with mean-method
+  has_mean <- function(x) {
+    if.numeric(x) |
+      inherits(x, what = c("Date", "POSIXct", "POSIXlt", "difftime"))
+  }
+  use <- vapply(df, has_mean, logical(1))
+  
+  # drop=FALSE so single columns work as expected!
+  df_numeric <- df[, use, drop = FALSE]
+  
+  # check for zero dims *after* selecting columns so all-character
+  # and all-factor data.frames get picked up as well.
+  if (any(dim(df_numeric) == 0)) {
+    rows_columns_zero <- as.character(c(10, 1) %*% (dim(df_numeric) == 0))
+    warning("<df> has zero ", 
+      switch(rows_columns_zero, 
+        "1"  = "columns", 
+        "10" = "rows", 
+        "0" = "rows and columns"), 
+      "for which a mean-method is defined")
+    return(data.frame())
+  }
+  
+  as.data.frame(lapply(df_numeric, mean, na.rm = na.rm))
+}
+```
+```{r, col_means_test, error=TRUE}
+```

--- a/feedback/defensive-count-sol.Rmd
+++ b/feedback/defensive-count-sol.Rmd
@@ -1,0 +1,66 @@
+```{r, child = "defensive-count-ex.Rmd"}
+```
+
+----------------------------------------------------
+
+### Lösung:
+
+a)  
+
+Implizite Annahmen über `supposedly_a_count` von denen abhängt ob der 
+ursprünglichen Code das erwartete Verhalten hat:
+
+- `supposedly_a_count` ist was numerisches
+- `supposedly_a_count` hat Länge 1
+- `supposedly_a_count` ist nicht `NA` oder `NaN`
+- `supposedly_a_count` ist nicht negativ
+- `supposedly_a_count` ist nicht unendlich
+
+
+b)  
+
+Strenge Variante:
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  checkmate::assert_number(supposedly_a_count,
+                           lower = 0, finite = TRUE,
+                           null.ok = FALSE, na.ok = FALSE
+  ) # defaults, not necessary
+  if (!checkmate::test_count(supposedly_a_count)) {
+    warning(
+      "rounding ", supposedly_a_count,
+      "to the nearest integer."
+    )
+    supposedly_a_count <- round(supposedly_a_count)
+  }
+  #always return an integer:
+  as.integer(supposedly_a_count)
+}  
+```
+
+Nachsichtigere Variante:
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  if (length(supposedly_a_count) > 1) {
+    warning("only using first element of supposedly_a_count")
+    supposedly_a_count <- supposedly_a_count[1]
+  }
+  checkmate::assert_number(supposedly_a_count, finite = TRUE)
+  if (!checkmate::test_count(supposedly_a_count)) {
+    warning(
+      "rounding ", supposedly_a_count,
+      "to the nearest non-negative integer."
+    )
+    as.integer(max(0, round(supposedly_a_count)))
+  }
+}
+```
+
+Zu pragmatische Variante (ohne Warnungen, und die erste Zeile könnte schiefgehen...):
+```{r, eval = FALSE}
+count_them <- function(supposedly_a_count) {
+  supposedly_a_count <- round(as.numeric(supposedly_a_count[1]))
+  checkmate::assert_count(supposedly_a_count)
+  as.integer(supposedly_a_count)
+}  
+```

--- a/feedback/defensive-lag-sol.Rmd
+++ b/feedback/defensive-lag-sol.Rmd
@@ -1,0 +1,35 @@
+```{r, child = "defensive-lag-ex.Rmd"}
+```
+
+----------------------------------------------------
+### Lösung:
+
+Zum Beispiel:
+```{r, lag-def}
+# make a lagged version of x
+# inputs: x: a vector
+#         lag: how many lags?
+lag <- function(x, lag = 1L) {
+  checkmate::assert_atomic_vector(x, min.len = 1)
+  checkmate::assert_count(lag)
+  checkmate::assert_number(lag, upper = length(x))
+  c(rep(NA, lag), x[seq_len(length(x) - lag)])
+}
+```
+```{r, lag-test, error=TRUE}
+x <- seq_len(10)
+
+testthat::expect_equal(lag(x, 2), c(NA, NA, x[1:8]))
+testthat::expect_equal(lag(x, 0), x)
+testthat::expect_equal(lag(x, 10), rep(NA_integer_, 10))
+
+# these should all give errors that are triggered by input checks:
+testthat::expect_error(lag(list(1, 2)))
+testthat::expect_error(lag(matrix(1:2, 1, 2)))
+testthat::expect_error(lag(data.frame(1, 2)))
+
+testthat::expect_error(lag(x, 11))
+testthat::expect_error(lag(x, -1))
+testthat::expect_error(lag(x, c(1, 3)))
+testthat::expect_error(lag(x, .2))
+```


### PR DESCRIPTION
:tada:  **(großteils) SCHÖÖÖN** :tada: 

DETAILKRITIK:

*`colmeans`*:  
 `as.data.frame(df[, numeric])` : hier fehlt ein `drop = FALSE`!

*`count`*: 
muss ein Rückgabeobjekt in der letzten Zeile definieren, sonst passiert evtl das hier:
```{r}
str(count_them(1L))
# NULL
```
(warum? mal nachdenken und mir nächstes mal erklären... :smirk: )

*`lag`*:  

- obwohl so viel Aufwand betrieben nicht präzise genug die inputs gecheckt:
```{r}
lag(1:3, -1)
Error in rep(NA, n) : invalid 'times' argument
```
:crying_cat_face: 
- für listen einfach `unlist` zu machen ist mir zu brutal:
```r
> list(1:3, 1:3)
[[1]]
[1] 1 2 3

[[2]]
[1] 1 2 3

> lag(list(1:3, 1:3), 1)
[1] NA  1  2  3  1  2
Warning message:
In lag(list(1:3, 1:3), 1) : converting 123123 from list to vector object
```
Dass das Ergebnis hier das ist was man möchte würde ich bezweifeln....